### PR TITLE
Add Catalan translation + fix to Spanish translation

### DIFF
--- a/alfresco/messages/zk-online-edition_ca.properties
+++ b/alfresco/messages/zk-online-edition_ca.properties
@@ -1,0 +1,1 @@
+zk.label.online.edition=Edita en l\u00ednia amb el LO

--- a/alfresco/messages/zk-online-edition_es.properties
+++ b/alfresco/messages/zk-online-edition_es.properties
@@ -1,1 +1,1 @@
-zk.label.online.edition=Editar Online con LO
+zk.label.online.edition=Editar en l\u00ednea con LO


### PR DESCRIPTION
I’ve changed the Spanish translation to use sentence case (as the Title Case style is incorrect in Spanish) and translated the term “online” to “en línea”.

I’ve provided a Catalan version in a separate commit.